### PR TITLE
Fix to bug #148, redirect user to first catalog page

### DIFF
--- a/presentation-layer/assets/js/main.js
+++ b/presentation-layer/assets/js/main.js
@@ -239,7 +239,7 @@ $( document ).ready(function() {
                     '<b> Camera: </b>'+ camera +'</br>' +
                     '<b> Dimensions: </b>'+ dimensions +'</br>' +
                     '<b> Weight: </b>'+ weight +'</br>' +
-                    '<b> Price: </b>'+ price+'</br>'));
+                    '<b> Price: </b>'+ price));
                 break;
         }
     }


### PR DESCRIPTION
Fix to bug #148, redirect user to first catalog page i.e catalog/desktop.

Note: We could direct the user back to the last page, but if the user was on order then clicks shopping cart, followed by continue shopping he would be directed to order.

Since desktop is the first catalog page, we will just redirect here. Unless someone comes with a better option.