### PR TITLE
Fix to bug #148, redirect user to first catalog page 

### DIFF
--- a/presentation-layer/views/client/shoppingCart.ejs
+++ b/presentation-layer/views/client/shoppingCart.ejs
@@ -51,7 +51,7 @@
                         <tr>
                             <td>   </td>
                             <td>
-                                <button type="button" class="btn btn-default">
+                                <button type="button" class="btn btn-default" onclick="window.location.href='/catalog/desktops'">
                                     <span class="glyphicon glyphicon-shopping-cart"></span> Continue Shopping
                                 </button></td>
                             <td>


### PR DESCRIPTION
 Fix to bug #148, redirect user to first catalog page i.e catalog/desktop.

Note: We could direct the user back to the last page, but if the user was on order then clicks shopping cart, followed by continue shopping he would be directed to order.

Since desktop is the first catalog page, we will just redirect here. Unless someone comes with a better option.